### PR TITLE
Add GCS Upload Stage to Jenkins Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,38 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  forkCount: '1C',
+  useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],
-])
+  ]
+)
+
+pipeline {
+    agent any
+
+    environment {
+        GCS_BUCKET = 'your-bucket-name'  // Replace with your actual GCS bucket name
+        GCS_CREDENTIALS_ID = 'your-jenkins-credentials-id' // Set in Jenkins credentials
+    }
+
+    stages {
+        stage('Upload to GCS') {
+            steps {
+                script {
+                    googleStorageUpload(
+                        credentialsId: GCS_CREDENTIALS_ID,
+                        bucket: GCS_BUCKET,
+                        pattern: '**/*.txt',  // Upload all text files
+                        sharedPublicly: false, // Set true if public access is needed
+                        metadata: [
+                            "Content-Type": "text/plain",
+                            "Content-Encoding": "gzip"
+                        ]
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR enhances the Jenkins pipeline by adding a new stage to upload files to Google Cloud Storage (GCS). The upload step includes setting metadata such as MIME type (Content-Type) and compression (Content-Encoding).

Changes Made:
Added a new "Upload to GCS" stage in Jenkinsfile.
Integrated googleStorageUpload function for file uploads.
Configured metadata to set correct MIME type and compression.
Used Jenkins credentials for secure authentication.
Why This Change?
Enables automated file uploads to GCS as part of the CI/CD pipeline.
Ensures proper file handling with metadata settings.
Improves workflow efficiency by automating cloud storage integration.
How to Test?
Run the Jenkins job after merging.
Verify that files are successfully uploaded to GCS.
Check the metadata in GCS to ensure correct Content-Type and Content-Encoding.
